### PR TITLE
Add Timeline Syntax Highlighting

### DIFF
--- a/documentation/timeline-text-syntax.md
+++ b/documentation/timeline-text-syntax.md
@@ -21,7 +21,7 @@ Timelines are saved in a text format, which means that you can use any text-edit
 
 Most events follow a shortcodes-like style:
 
-```
+```dtl
 [background path="res://icon.png" fade="1.0"]
 ```
 

--- a/documentation/timeline-text-syntax.md
+++ b/documentation/timeline-text-syntax.md
@@ -1,7 +1,7 @@
 ![header_text_syntax](media/headers/text_syntax.png)
 
 Timelines are saved in a text format, which means that you can use any text-editing software to edit and create them. The built in text editor provides useful autocompletion and syntax highlighting.
-📜 
+📜
 *Info: For dialogic to register your timeline file, it has to use the `.dtl` extension!*
 
 <details open>
@@ -14,7 +14,7 @@ Timelines are saved in a text format, which means that you can use any text-edit
 - [About Indentation](#about-indentation)
 
 - [Example Timeline](#Example-timeline)
-  
+
   </details>
 
 ## About shortcode events
@@ -33,51 +33,51 @@ To find all of the parameters you can use on each event, check out their documen
 
 Some events have a custom syntax, to make writing them easier. This includes:
 
-- Character event: 
-  
+- Character event:
+
   - `join Emilio (happy) 3 [animation="Bounce In"]`
   - `leave Emilio [animation="Bounce Out" length="0.3"]`
   - `update Emilio (excited) 4 [animation="Tada" wait="true" repeat="3" move_time="0.3"]`
 
 - Text event: 
-  
+
   - `A wonderful text event, said by noone in particular.`
   - `Emilio (excited): Hello and welcome!`
   - Ending a text event with \ will make it include the next line as well.
 
 - Choice event:
-  
+
   - `- I don't know about that`
   - `- Yes [if {John.Relationship} > 23]`
   - `- Sure, I'm the great wizard [if {Stats.Charisma} > 10] [else="disable" alt_text="I'm the great wizard [to insecure]"]`
 
-- Condition event: 
-  
+- Condition event:
+
   - `if {Player.Wisdom} > 3:`
   - `elif {Player.Health} <= 10:`
   - `else:`
 
-- Set Variable event: 
-  
+- Set Variable event:
+
   - `set {MyVariable} += 10`
   - Supported Operators are =, += , -= , *=, /=
 
 - Comment event:
-  
+
   - `# Todo: Finnish this!!!!`
 
 - Label event:
-  
+
   - `label MyLabelName`
 
 - Jump event:
-  
+
   - `jump MyLabelName`
   - `jump TimelineName/` # the slash is mandatory to clarify this is a timeline not a label
   - `jump TimelineName/LabelName`
 
 - Return event:
-  
+
   - `return`
 
 ## About indentation
@@ -86,13 +86,13 @@ Timelines use TAB indentation to know what events belong to a choice or conditio
 
 ## Example timeline
 
-```
+```dtl
 [background path="res://assets/backgroudns/dialogic_factory.png"]
 
 join Jowan 4
 jowan (exited): Hello and welcome to[portrait=confused]...[pause=0.5] Wait? What is this?
 
-Join Emilio (happy) 1
+join Emilio (happy) 1
 Emilio: Well, this is is the example timeline.
 
 Jowan: I thought this was a cool new feature?

--- a/theme/ayu-highlight.css
+++ b/theme/ayu-highlight.css
@@ -37,7 +37,7 @@ code.hljs .hljs-keyword { color: var(--keyword-color); }
 
 code.hljs .hljs-control_flow_keyword { color: var(--control_flow_keyword-color); }
 
-code.hljs .hljs-base_type { color: var(--base_type-color); }
+code.hljs .hljs-base_type, .hljs-built_in { color: var(--base_type-color); }
 
 code.hljs .hljs-engine_type { color: var(--engine_type-color); }
 

--- a/theme/highlight.js
+++ b/theme/highlight.js
@@ -142,7 +142,6 @@ function hljsDefineDialogicTimeline(hljs) {
             SPEAKER_TEXT,
             SPEAKER_EXPRESSION,
 			SPEAKER_ARGUMENT,
-			ESCAPED_EVENT_BRACKTS,
 			hljs.NUMBER_MODE,
 			hljs.HASH_COMMENT_MODE,
 			{

--- a/theme/highlight.js
+++ b/theme/highlight.js
@@ -134,6 +134,11 @@ function hljsDefineDialogicTimeline(hljs) {
         begin: '\\([^)]+\\)'
     };
 
+	var EVENT_PROPERTY = {
+		className: 'built_in',
+		begin: '\\b[A-Za-z]+\\b(?=\\s*=)'
+	  };
+
 	return {
 		aliases: ['dtl', 'timeline'],
 		keywords: KEYWORDS,
@@ -141,6 +146,7 @@ function hljsDefineDialogicTimeline(hljs) {
             SPEAKER_NAME,
             SPEAKER_TEXT,
             SPEAKER_EXPRESSION,
+			EVENT_PROPERTY,
 			SPEAKER_ARGUMENT,
 			hljs.NUMBER_MODE,
 			hljs.HASH_COMMENT_MODE,

--- a/theme/highlight.js
+++ b/theme/highlight.js
@@ -79,4 +79,96 @@ function hljsDefineGDScript(hljs) {
 	};
 }
 
+
+/*
+    Function returns a highlight definition for GDScript.
+*/
+function hljsDefineDialogicTimeline(hljs) {
+	var KEYWORDS = {
+        /* General keywords */
+		keyword:
+			'join leave update set jump label background set call ' +
+            'music voice sound style clear history end_timeline ',
+
+        /* Keywords altering the code flow. */
+        control_flow_keyword:
+            'if and elif else for match while break continue pass return ',
+
+        /* Improves the Dialogic Autoload's visual clarity. */
+        dialogic_keyword:
+            '',
+
+        /* Built-in types in GDScript. */
+        built_in:
+            '',
+
+		literal:
+			'true false null'
+	};
+
+    var SPEAKER_NAME = {
+        className: 'dialogic_keyword',
+        begin: '\\b[A-Za-z]+\\b(?=\\s*(\\([^)]+\\)|:))'
+    };
+
+    var SPEAKER_TEXT = {
+        className: 'string',
+        begin: ':',
+        end: '$',
+        relevance: 0,
+        contains: []
+    };
+
+	var SPEAKER_EXPRESSION = {
+        className: 'built_in',
+        begin: '\\([^)]+\\)'
+    };
+
+	var SPEAKER_ARGUMENT = {
+		className: 'dialogic_keyword',
+		begin: '(?<=\\b(?:join|leave|jump|label|update)\\s)\\b[A-Za-z]+\\b'
+	  };
+
+    var SPEAKER_EXPRESSION = {
+        className: 'built_in',
+        begin: '\\([^)]+\\)'
+    };
+
+	return {
+		aliases: ['dtl', 'timeline'],
+		keywords: KEYWORDS,
+		contains: [
+            SPEAKER_NAME,
+            SPEAKER_TEXT,
+            SPEAKER_EXPRESSION,
+			SPEAKER_ARGUMENT,
+			ESCAPED_EVENT_BRACKTS,
+			hljs.NUMBER_MODE,
+			hljs.HASH_COMMENT_MODE,
+			{
+				className: 'comment',
+				begin: /"""/, end: /"""/
+			},
+			hljs.QUOTE_STRING_MODE,
+			{
+				variants: [
+					{
+						className: 'function',
+						beginKeywords: 'func'
+					},
+					{
+						className: 'class',
+						beginKeywords: 'class'
+					}
+				],
+				end: /:/,
+				contains: [
+					hljs.UNDERSCORE_TITLE_MODE
+				]
+			},
+		]
+	};
+}
+
 hljs.registerLanguage('gdscript', hljsDefineGDScript);
+hljs.registerLanguage('dialogic-timeline', hljsDefineDialogicTimeline);


### PR DESCRIPTION
Adds syntax highlighting for Dialogic Timelines.

Example using the Ayu theme:
![image](https://github.com/dialogic-godot/documentation/assets/65981767/2ac075c1-0e03-40ba-b909-2b6adae8c192)
