### PR TITLE
Fix indentation on signal page

### DIFF
--- a/documentation/dialogic-signals.md
+++ b/documentation/dialogic-signals.md
@@ -74,24 +74,24 @@ Dialogic subsystems have many useful signals. Here is a selection of them:
 
 - `Dialogic.Text` has
 
-  - signal `about_to_show_text(info:Dictionary)`
-  - signal `text_finished(info:Dictionary)`
-  - signal `speaker_updated(character:DialogicCharacter)`
-  - signal `textbox_visibility_changed(visible:bool)`
-  - signal `animation_textbox_new_text`
-  - signal `animation_textbox_show`
-  - signal `animation_textbox_hide`
+    - signal `about_to_show_text(info:Dictionary)`
+    - signal `text_finished(info:Dictionary)`
+    - signal `speaker_updated(character:DialogicCharacter)`
+    - signal `textbox_visibility_changed(visible:bool)`
+    - signal `animation_textbox_new_text`
+    - signal `animation_textbox_show`
+    - signal `animation_textbox_hide`
 
 - `Dialogic.Portraits` has
 
-  - signal `character_joined(info:Dictionary)`
-  - signal `character_left(info:Dictionary)`
-  - signal `character_portrait_changed(info:Dictionary)`
+    - signal `character_joined(info:Dictionary)`
+    - signal `character_left(info:Dictionary)`
+    - signal `character_portrait_changed(info:Dictionary)`
 
 - `Dialogic.VAR` has
 
-  - signal `variable_changed(info:Dictionary)`
-  - signal `variable_was_set(info:Dictionary)` # only on set variable events
+    - signal `variable_changed(info:Dictionary)`
+    - signal `variable_was_set(info:Dictionary)` # only on set variable events
 
 And many more. If you want to react to something particular happening, take a look to see if the responsible subsystem has a signal for that.
 


### PR DESCRIPTION
- Changed from 2 spaces to 4 spaces
- ~~Remove repetition of "signal" word~~

~~Context is very clear that everything is signal~~  
~~> Dialogic subsystems have many useful signals. Here is a selection of them:~~