### PR TITLE
Update saving-and-loading.md

### DIFF
--- a/documentation/saving-and-loading.md
+++ b/documentation/saving-and-loading.md
@@ -27,7 +27,7 @@ Here are the relevant methods:
 
 - `Dialogic.Save.get_slot_names()`
 
-- `Dialogic.Save.remove_slot(@slot_name)`
+- `Dialogic.Save.delete_slot(@slot_name)`
 
 - `Dialogic.Save.reset_slot(@slot_name)`
 


### PR DESCRIPTION
Previously, had delete_slot() method as remove_slot(), which would throw an error.