### PR TITLE
Update creating-extensions.md

### DIFF
--- a/documentation/creating-extensions.md
+++ b/documentation/creating-extensions.md
@@ -207,7 +207,7 @@ Be aware, you have to:
 - **orig_pos** = the position you started at
 
 ## Naming animations
-Importantly the name of your animation file will determine if it is a Join, Leave or Update animation! If it ends with `_in` or contains `_in_` it is a join animation, ending in `_out` or containing `_out_` makes it a leave animation, while all other names are concidered update animations (often called attention seekers in other software). 
+Importantly the name of your animation file will determine if it is a Join, Leave or Update animation! If it ends with `_in` or contains `_in_` it is a Join animation, ending in `_out` or containing `_out_` makes it a Leave animation, while all other names are considered Update animations (often called attention seekers in other software). 
 
 ---
 

--- a/documentation/creating-extensions.md
+++ b/documentation/creating-extensions.md
@@ -207,7 +207,7 @@ Be aware, you have to:
 - **orig_pos** = the position you started at
 
 ## Naming animations
-Importantly the name of your animation file will determine if it is a Join, Leave or Update animation! If it ends with `_in` it is a join animation, ending in `_out` makes it a leave animation, while all other names are concidered update animations (often called attention seekers in other software). 
+Importantly the name of your animation file will determine if it is a Join, Leave or Update animation! If it ends with `_in` or contains `_in_` it is a join animation, ending in `_out` or containing `_out_` makes it a leave animation, while all other names are concidered update animations (often called attention seekers in other software). 
 
 ---
 


### PR DESCRIPTION
Slight change to custom animation documentation based on testing. The default animation "slide_in_left" is only available on the "join" action for character's, however it does not end in "_in". I created my custom animation according to the documentation resulting in an "update" animation, however after adding "\_in\_" to the middle of the filename it was added to the list of options for "join".

![image](https://github.com/dialogic-godot/documentation/assets/46795239/2d052159-c136-4ebd-a37e-5f51a0b20b18)
