### PR TITLE
Add warning about existing files

### DIFF
--- a/documentation/creating-extensions.md
+++ b/documentation/creating-extensions.md
@@ -30,6 +30,10 @@ The best way to create an extension is to use the extension creator in the dialo
 
 By clicking the `Create New Extension` button, you can set up an extension folder and a custom event script. Enter a name for the new module and select what you would like to add. Then click `Create`.
 
+```admonish warning
+Existing files will be overwritten!
+```
+
 ---
 
 ## 2. The essential part: `index.gd`


### PR DESCRIPTION
I recently was caught unawares trying to add a subsystem to an extension I had created (and aside from the extension creator mode being swapped), it overwrote my existing files. It wasn't what I expected to happen, so adding a warning seemed appropriate.